### PR TITLE
添加蓝牙状态灯、添加POWER_SAVE_MODE配置项、修正小错误

### DIFF
--- a/main/ble/battery_service.c
+++ b/main/ble/battery_service.c
@@ -207,6 +207,7 @@ static uint16_t adc_result_calc()
 }
 
 static void ADC_switch_to_slow_mode() {
+    uint32_t err_code;
     err_code = app_timer_stop(m_battery_timer_id);
     err_code = app_timer_start(m_battery_timer_id, BATTERY_LEVEL_MEAS_INTERVAL_SLOW, NULL);
     APP_ERROR_CHECK(err_code);
@@ -224,7 +225,6 @@ static void ADC_appsh_mes_evt_handler(void *p_event_data, uint16_t event_size)
 {
     UNUSED_PARAMETER(p_event_data);
     UNUSED_PARAMETER(event_size);
-    uint32_t err_code;
 
     if (adc_result_queue_index >= ADC_RESULT_QUEUE_SIZE)
     {

--- a/main/ble/main.c
+++ b/main/ble/main.c
@@ -319,6 +319,7 @@ void sleep_mode_enter(bool notice)
 
     if(notice)led_notice(0x00, true);
     else led_notice(0x00, false);
+	  set_blue_led(false);
     matrix_sleep_prepare();
 #ifdef UART_SUPPORT
     uart_sleep_prepare();
@@ -444,14 +445,18 @@ void uart_state_change(bool state)
     {
         err_code = app_timer_stop(m_keyboard_sleep_timer_id);
         APP_ERROR_CHECK(err_code);
+			  #ifdef POWER_SAVE_MODE
         led_powersave_mode(false);
+			  #endif
         keyboard_switch_scan_mode(false);
     }
     else
     {
         err_code = app_timer_start(m_keyboard_sleep_timer_id, KEYBOARD_FREE_INTERVAL, NULL);
         APP_ERROR_CHECK(err_code);
+			  #ifdef POWER_SAVE_MODE
         led_powersave_mode(true);
+			  #endif
     }
 }
 #endif
@@ -490,10 +495,10 @@ int main(void)
     wdt_init();
     err_code = ble_advertising_start(BLE_ADV_MODE_FAST);
     APP_ERROR_CHECK(err_code);
-    
+#ifdef POWER_SAVE_MODE   
     led_change_handler(0x01, true);
     led_notice(0x07, 0x00);
-    
+#endif
 #ifdef UART_SUPPORT
     uart_state_change(uart_current_mode != UART_MODE_IDLE);
 #endif

--- a/main/keyboard/config.h
+++ b/main/keyboard/config.h
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID      0xEEEE
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    "Lotlab"
-#define DESCRIPTION     t.m.k. keyboard firmware for GH60
+#define DESCRIPTION     BLE keyboard base t.m.k firmware
 
 #ifdef KEYBOARD_4100
 
@@ -59,6 +59,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     
     //#define KEYBOARD_DEBUG
     #define KEYBOARD_REVA
+	//#define POWER_SAVE_MODE     //省电模式选项，启用此选项后键盘指示灯仅闪烁一次，不常亮
     
     #define UART_SUPPORT
     #define BLE_LINK_SEC       //启用此选项，蓝牙配对时要求输入密码,并启用MITM

--- a/main/keyboard/keyboard_conf.h
+++ b/main/keyboard/keyboard_conf.h
@@ -35,9 +35,9 @@ static const uint8_t column_pin_array[MATRIX_COLS] = {3,4,5,6,7,15,14,10,9,8,2,0
 #ifdef KEYBOARD_60
 
 #define LED_CAPS 18
-#define LED_EXT1 16
-#define LED_EXT2 14
-#define LED_EXT3 12
+#define LED_NUM 16
+#define LED_BLE 14
+#define LED_BATT 12
 #define LED_EXT4 10
 #define LED_EXT5 8
 
@@ -48,12 +48,12 @@ static const uint8_t row_pin_array[MATRIX_ROWS] = {24,25,26,27,28};
 
 #define BOOTLOADER_BUTTON 20
 #define UPDATE_IN_PROGRESS_LED      LED_CAPS
-#define ADVERTISING_LED_PIN_NO      LED_EXT1
-#define CONNECTED_LED_PIN_NO        LED_EXT2
+#define ADVERTISING_LED_PIN_NO      LED_NUM
+#define CONNECTED_LED_PIN_NO        LED_BLE
 #define LED_POSITIVE
 
 /**
- * @brief 此版本中有一个硬件设计错误，导致ADC电量测量无法使用。这里将其关闭。
+ * @brief REVA版本中有一个硬件设计错误，导致ADC电量测量无法使用。这里将其关闭。
  * 
  */
 #ifdef KEYBOARD_REVA

--- a/main/keyboard/keyboard_led.c
+++ b/main/keyboard/keyboard_led.c
@@ -15,8 +15,13 @@
 
 bool m_led_state[3] = {false};                    /**< LED State. */
 bool counting;
+#ifdef POWER_SAVE_MODE
 bool led_autooff = true;
+#else
+bool led_autooff = false;
+#endif
 APP_TIMER_DEF(led_off);
+
 
 /**
  * @brief 底层设置LED状态
@@ -33,6 +38,30 @@ void set_led_num(uint8_t num)
 #endif
 #ifdef LED_SCLK
     nrf_gpio_pin_write(LED_SCLK, num & 0x04);
+#endif
+}
+
+/**
+ * @brief 底层设置蓝牙LED指示灯状态
+ * 
+ * @param val 
+ */
+void set_blue_led(uint8_t val)
+{
+#ifdef LED_BLE
+    nrf_gpio_pin_write(LED_BLE, val);
+#endif
+}
+
+/**
+ * @brief 底层设置电池LED指示灯状态
+ * 
+ * @param val 
+ */
+void set_battery_led(uint8_t val)
+{
+#ifdef LED_BATT
+    nrf_gpio_pin_write(LED_BATT, val);
 #endif
 }
 
@@ -63,9 +92,9 @@ void led_notice(uint8_t num, uint8_t type)
     }
 }
 /**
- * @brief 设置LED状态
+ * @brief 设置三个键盘LED状态
  * 
- * @param usb_led 三个LED位的值
+ * @param usb_led 三个键盘LED位的值
  */
 void led_set(uint8_t usb_led)
 {
@@ -118,6 +147,12 @@ void led_init(void)
 #endif
 #ifdef LED_SCLK
     nrf_gpio_cfg_output(LED_SCLK);
+#endif
+#ifdef LED_BLE
+    nrf_gpio_cfg_output(LED_BLE);
+#endif
+#ifdef LED_BATT
+    nrf_gpio_cfg_output(LED_BATT);
 #endif
     app_timer_create(&led_off, APP_TIMER_MODE_SINGLE_SHOT, led_turnoff);
 }

--- a/main/keyboard/keyboard_led.h
+++ b/main/keyboard/keyboard_led.h
@@ -9,5 +9,7 @@ void led_notice(uint8_t num, uint8_t type);
 void led_change_handler(uint8_t val, uint8_t all);
 void led_powersave_mode(bool powersave);
 void led_init(void);
+void set_blue_led(uint8_t val);
+void set_battery_led(uint8_t val);
 
 #endif

--- a/main/keyboard/uart_driver.c
+++ b/main/keyboard/uart_driver.c
@@ -147,9 +147,11 @@ void uart_data_handler()
     case PACKET_CHARGING:
         if (recv.data[0] == 0x00)
         { // full
+				set_battery_led(true);
         }
         else
         { // charging
+				set_battery_led(false);
         }
         break;
     case PACKET_FAIL:    
@@ -304,7 +306,11 @@ void uart_task(void *p_context)
             uart_current_mode = UART_MODE_CHARGING;
             uart_state_change_invoke();
         }
+		    set_blue_led(true);
     }
+		if (uart_is_using_usb()){
+				set_blue_led(false);
+		}
 }
 
 /**
@@ -409,9 +415,11 @@ void uart_switch_mode()
     {
         case UART_MODE_USB:
             uart_current_mode = UART_MODE_BLE_OVERRIDE;
+						set_blue_led(true);
             break;
         case UART_MODE_BLE_OVERRIDE:
             uart_current_mode = UART_MODE_USB;
+					  set_blue_led(false);
             break;
         default:
             break;


### PR DESCRIPTION
1、修正battery_service.c小错误
2、添加蓝牙状态灯，在蓝牙连接时常亮，在蓝牙断开是关闭。如USB插入状态，蓝牙是始终开启状态，此时蓝牙灯常亮代表采用蓝牙连接输入，蓝牙灯熄灭代表采用USB连接输入。
3、添加了配置项POWER_SAVE_MODE，启用此配置项，在蓝牙连接下键盘灯仅闪烁一次进行提示，不启用键盘指示灯将常亮提示状态，